### PR TITLE
Fix tetrimino spawn height

### DIFF
--- a/board.js
+++ b/board.js
@@ -55,13 +55,28 @@ export class Board {
   }
 
   mergeTetrimino(tetrimino) {
+    let aboveVisible = false;
     for (let y = 0; y < tetrimino.size; y++) {
       for (let x = 0; x < tetrimino.size; x++) {
         if (tetrimino.matrix[y][x]) {
-          this.grid[y + tetrimino.y][x + tetrimino.x] = tetrimino.color;
+          const boardY = y + tetrimino.y;
+          const boardX = x + tetrimino.x;
+          if (boardY < 0) {
+            aboveVisible = true;
+            continue; // Skip cells above the visible board
+          }
+          if (
+            boardY >= this.height ||
+            boardX < 0 ||
+            boardX >= this.width
+          ) {
+            continue;
+          }
+          this.grid[boardY][boardX] = tetrimino.color;
         }
       }
     }
+    return aboveVisible;
   }
 
   clearLines() {

--- a/game.js
+++ b/game.js
@@ -155,11 +155,11 @@ export class Game {
       this.tetrimino.x += deltaX;
       this.tetrimino.y += deltaY;
     } else if (deltaY > 0) {
-      this.board.mergeTetrimino(this.tetrimino);
+      const above = this.board.mergeTetrimino(this.tetrimino);
       this.board.clearLines();
       this.tetrimino = new Tetrimino();
 
-      if (this.board.hasCollision(this.tetrimino)) {
+      if (above || this.board.hasCollision(this.tetrimino)) {
         this.gameOver();
       }
     }

--- a/tests/tetrimino.test.js
+++ b/tests/tetrimino.test.js
@@ -18,9 +18,9 @@ describe('Tetrimino', () => {
       // Assuming default x is roughly center of board (e.g., boardWidth/2 - size/2)
       // and y is 0.
       // For now, let's check if they are numbers. Specific values depend on board context.
-      // The current tetrimino.js constructor sets x = 3, y = 0.
+      // Pieces spawn completely above the board so they can drop into view
       expect(tetrimino.x).toBe(3);
-      expect(tetrimino.y).toBe(0);
+      expect(tetrimino.y).toBe(-tetrimino.size);
     });
 
     it('should handle unknown shape types gracefully (e.g., default to a specific shape or throw error)', () => {

--- a/tetrimino.js
+++ b/tetrimino.js
@@ -23,7 +23,8 @@ export class Tetrimino {
     this.color = shapeData.color;
     this.size = this.matrix.length; // Assuming square matrices from shapes.js
     this.x = 3; // As per test expectation (or Math.floor((10 - this.size) / 2) for centering on a 10-wide board)
-    this.y = 0; // As per test expectation
+    // Start completely above the visible board so even the tallest piece is hidden
+    this.y = -this.size;
   }
 
   draw(ctx) {


### PR DESCRIPTION
## Summary
- spawn new tetriminos a couple of rows above the board
- ignore cells above the board when merging
- end the game if a piece locks while above the visible area
- update tests for new spawn position
- spawn pieces fully above the board for tallest piece

## Testing
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_6840d92648fc8324af4ebffd2196c21e