### PR TITLE
Add next piece preview

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,10 +2,12 @@ import { Board } from "./board.js";
 import { Tetrimino } from "./tetrimino.js";
 
 export class Game {
-  constructor(ctx) {
+  constructor(ctx, previewCtx = null) {
     this.ctx = ctx;
+    this.previewCtx = previewCtx;
     this.board = new Board();
     this.tetrimino = new Tetrimino();
+    this.nextTetrimino = new Tetrimino();
     this.gravityInterval = 500;
     this.lastDropTime = Date.now();
     this.boundKeyDownHandler = null;
@@ -21,7 +23,8 @@ export class Game {
     }
     this.initControls(); // Ensure controls are initialized for a new game
     this.board = new Board();
-    this.tetrimino = new Tetrimino();
+    this.tetrimino = this.nextTetrimino;
+    this.nextTetrimino = new Tetrimino();
     this.gameLoop();
   }
 
@@ -148,6 +151,7 @@ export class Game {
     this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
     this.board.draw(this.ctx);
     this.tetrimino.draw(this.ctx);
+    this.drawPreview();
   }
 
   moveTetrimino(deltaX, deltaY) {
@@ -157,7 +161,8 @@ export class Game {
     } else if (deltaY > 0) {
       const above = this.board.mergeTetrimino(this.tetrimino);
       this.board.clearLines();
-      this.tetrimino = new Tetrimino();
+      this.tetrimino = this.nextTetrimino;
+      this.nextTetrimino = new Tetrimino();
 
       if (above || this.board.hasCollision(this.tetrimino)) {
         this.gameOver();
@@ -205,6 +210,24 @@ export class Game {
     // this.tetrimino.y = originalY;
   }
 
+  drawPreview() {
+    if (!this.previewCtx) return;
+    const ctx = this.previewCtx;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    const tet = this.nextTetrimino;
+    const cell = this.board.cellSize;
+    for (let y = 0; y < tet.size; y++) {
+      for (let x = 0; x < tet.size; x++) {
+        if (tet.matrix[y][x]) {
+          ctx.fillStyle = tet.color;
+          ctx.fillRect(x * cell, y * cell, cell, cell);
+          ctx.strokeStyle = "#222";
+          ctx.strokeRect(x * cell, y * cell, cell, cell);
+        }
+      }
+    }
+  }
+
   gameOver() {
     alert("Game Over");
     cancelAnimationFrame(this.gameLoopId);
@@ -214,3 +237,4 @@ export class Game {
     this.tetrimino = new Tetrimino();
   }
 }
+

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <body>
     <h1>Tetris</h1>
     <canvas id="gameCanvas" width="320" height="640"></canvas>
+    <canvas id="nextCanvas" width="128" height="128"></canvas>
     <button id="startGame">Start Game</button>
     <script type="module" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -2,7 +2,9 @@ import { Game } from "./game.js";
 
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
-const game = new Game(ctx);
+const nextCanvas = document.getElementById("nextCanvas");
+const nextCtx = nextCanvas.getContext("2d");
+const game = new Game(ctx, nextCtx);
 
 document.getElementById("startGame").addEventListener("click", () => {
   game.start();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {
     "type": "git",

--- a/style.css
+++ b/style.css
@@ -48,3 +48,7 @@ canvas {
     background-color: black;
     opacity: 1;
 }
+
+#nextCanvas {
+    margin-left: 10px;
+}

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,57 @@
+import { Game } from '../game.js';
+import { jest } from '@jest/globals';
+
+// Helper to create a dummy canvas context
+function createDummyCtx() {
+  return {
+    canvas: { width: 320, height: 640 },
+    fillRect: jest.fn(),
+    strokeRect: jest.fn(),
+    clearRect: jest.fn(),
+  };
+}
+
+describe('Game next piece preview', () => {
+  let dummyCtx;
+  beforeEach(() => {
+    // Minimal DOM stubs for event listeners
+    global.document = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    global.requestAnimationFrame = jest.fn();
+    global.cancelAnimationFrame = jest.fn();
+    global.alert = jest.fn();
+    dummyCtx = createDummyCtx();
+  });
+
+  afterEach(() => {
+    delete global.document;
+    delete global.requestAnimationFrame;
+    delete global.cancelAnimationFrame;
+    delete global.alert;
+  });
+
+  it('initializes with a nextTetrimino', () => {
+    const game = new Game(dummyCtx);
+    expect(game.nextTetrimino).toBeDefined();
+  });
+
+  it('uses nextTetrimino when current piece locks', () => {
+    const game = new Game(dummyCtx);
+    const firstNext = game.nextTetrimino;
+
+    // Force collision on downward movement
+    game.board.hasCollision = jest
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    game.board.mergeTetrimino = jest.fn();
+    game.board.clearLines = jest.fn();
+
+    game.moveTetrimino(0, 1);
+
+    expect(game.tetrimino).toBe(firstNext);
+    expect(game.nextTetrimino).not.toBe(firstNext);
+  });
+});


### PR DESCRIPTION
## Summary
- enable jest ESM support
- show next tetrimino preview in its own canvas
- add Game.nextTetrimino and preview drawing
- update main game start to use preview canvas
- style next piece preview
- test next piece functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f5dd00b88324b03ff85d35bd6ab2