### PR TITLE
Move start button to side and enlarge

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,13 @@
 </head>
 <body>
     <h1 class="fancy-title">Tetris</h1>
-    <div class="board-container">
-        <canvas id="nextCanvas" width="128" height="128"></canvas>
-        <canvas id="gameCanvas" width="320" height="640"></canvas>
+    <div class="game-container">
+        <div class="board-container">
+            <canvas id="nextCanvas" width="128" height="128"></canvas>
+            <canvas id="gameCanvas" width="320" height="640"></canvas>
+        </div>
+        <button id="startGame">Start</button>
     </div>
-    <button id="startGame">Start</button>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -46,14 +46,19 @@ canvas {
     align-items: flex-start;
 }
 
+.game-container {
+    display: flex;
+    align-items: flex-start;
+}
+
 #nextCanvas {
     margin-right: 10px;
 }
 
 #startGame {
-    margin-top: 20px;
-    padding: 10px 20px;
-    font-size: 1.2rem;
+    margin-left: 20px;
+    padding: 20px 40px;
+    font-size: 2rem;
     background-color: #28a745;
     color: #fff;
     border: none;

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -26,4 +26,19 @@ describe('UI layout', () => {
     const title = document.querySelector('h1');
     expect(title.classList.contains('fancy-title')).toBe(true);
   });
+
+  test('start button is positioned after the board container within game-container', () => {
+    const gameContainer = document.querySelector('.game-container');
+    expect(gameContainer).not.toBeNull();
+    const children = Array.from(gameContainer.children);
+    const boardIndex = children.findIndex(el => el.classList.contains('board-container'));
+    const buttonIndex = children.findIndex(el => el.id === 'startGame');
+    expect(boardIndex).toBeLessThan(buttonIndex);
+  });
+
+  test('start button has increased font size in CSS', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, '../style.css'), 'utf8');
+    const rule = /#startGame\s*{[^}]*font-size:\s*2rem;/;
+    expect(rule.test(css)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- layout: wrap board and start button in `.game-container`
- style: enlarge start button and move it to the right
- tests: verify button placement and updated size

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684158c7f3c48324a831ac70529e8561